### PR TITLE
Handle high numbered main panes

### DIFF
--- a/autoload/vimultiplex/main.vim
+++ b/autoload/vimultiplex/main.vim
@@ -172,7 +172,7 @@ function! vimultiplex#main#newest_pane_id()
     for i in pane_data
         let short_pane_id = i.pane_id
         let short_pane_id = substitute(short_pane_id, '%', '', '')
-        if max_found_id ==# '' || short_pane_id >=# max_found_id
+        if max_found_id ==# '' || short_pane_id + 0 >=# max_found_id + 0
             let found_pane = i
             let max_found_id = short_pane_id
         endif


### PR DESCRIPTION
I wasn't doing string coercions to strings properly, so when I started
with pane %4, and got pane %22, the system would not correctly guess the
correct newest pane (it would assume it was 4, because it was the
'highest' numbered by string ordering).

This adjusts that so that it actually uses integer comparisons to find
the highest ordered pane.