### PR TITLE
Protect vimultiplex main window on destroy_all

### DIFF
--- a/autoload/vimultiplex/main.vim
+++ b/autoload/vimultiplex/main.vim
@@ -178,7 +178,9 @@ function! vimultiplex#main#new()
     function! obj.destroy_all()
         for i in keys(self.windows)
             call self.windows[i].destroy_all()
-            call remove(self.windows, i)
+            if i !=# 'main'
+                call remove(self.windows, i)
+            endif
         endfor
     endfunction
 


### PR DESCRIPTION
The main window was getting deleted by the 'destroy_all' command,
leaving vimultiplex unusable afterwards (unless, of course, you knew the
internals).